### PR TITLE
feat(todoapp): Add mcp-server-todoapp package

### DIFF
--- a/packages/mcp-server-todoapp/build/index.js
+++ b/packages/mcp-server-todoapp/build/index.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { initTRPC } from '@trpc/server';
+import { z } from 'zod';
+const todos = [];
+let nextTodoId = 1;
+const t = initTRPC.context().create();
+const router = t.router;
+const publicProcedure = t.procedure;
+// 入力スキーマの定義
+const createTodoSchema = z.string();
+const updateTodoSchema = z.object({
+    id: z.number(),
+    completed: z.boolean(),
+});
+const deleteTodoSchema = z.number();
+// trpc ルーター定義
+const todoRouter = router({
+    createTodo: publicProcedure
+        .input(createTodoSchema)
+        .mutation(({ input }) => {
+        const todo = {
+            id: nextTodoId++,
+            text: input,
+            completed: false,
+        };
+        todos.push(todo);
+        return todo;
+    }),
+    listTodos: publicProcedure.query(() => {
+        return todos;
+    }),
+    updateTodo: publicProcedure
+        .input(updateTodoSchema)
+        .mutation(({ input }) => {
+        const todo = todos.find((t) => t.id === input.id);
+        if (!todo) {
+            throw new Error(`Todo with id ${input.id} not found`);
+        }
+        todo.completed = input.completed;
+        return todo;
+    }),
+    deleteTodo: publicProcedure
+        .input(deleteTodoSchema)
+        .mutation(({ input }) => {
+        const index = todos.findIndex((t) => t.id === input);
+        if (index === -1) {
+            throw new Error(`Todo with id ${input} not found`);
+        }
+        todos.splice(index, 1);
+        return { success: true };
+    }),
+});
+// MCP サーバーの初期化
+const server = new Server({
+    name: 'TodoApp MCP Server',
+    version: '0.1.0',
+}, {
+    capabilities: {
+        tools: {},
+    },
+});
+// ListToolsRequestSchema のハンドラー
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+        tools: [
+            {
+                name: 'create_todo',
+                description: 'Create a new todo item',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        text: { type: 'string', description: 'Todo item text' },
+                    },
+                    required: ['text'],
+                },
+            },
+            {
+                name: 'list_todos',
+                description: 'List all todo items',
+                inputSchema: {
+                    type: 'object',
+                    properties: {},
+                },
+            },
+            {
+                name: 'update_todo',
+                description: 'Update a todo item (e.g., mark as complete)',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'number', description: 'Todo item ID' },
+                        completed: { type: 'boolean', description: 'Completion status' },
+                    },
+                    required: ['id', 'completed'],
+                },
+            },
+            {
+                name: 'delete_todo',
+                description: 'Delete a todo item',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'number', description: 'Todo item ID' },
+                    },
+                    required: ['id'],
+                },
+            },
+        ],
+    };
+});
+// CallToolRequestSchema のハンドラー
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    switch (request.params.name) {
+        case 'create_todo': {
+            const text = request.params.arguments?.text;
+            if (typeof text !== 'string') {
+                throw new McpError(ErrorCode.InvalidParams, 'Text must be a string');
+            }
+            const todo = await todoRouter.createCaller({}).createTodo(text);
+            return {
+                content: [{ type: 'text', text: JSON.stringify(todo, null, 2) }],
+            };
+        }
+        case 'list_todos': {
+            const todos = await todoRouter.createCaller({}).listTodos();
+            return {
+                content: [{ type: 'text', text: JSON.stringify(todos, null, 2) }],
+            };
+        }
+        case 'update_todo': {
+            const args = request.params.arguments;
+            if (typeof args?.id !== 'number' ||
+                typeof args?.completed !== 'boolean') {
+                throw new McpError(ErrorCode.InvalidParams, 'Invalid arguments for update_todo');
+            }
+            const todo = await todoRouter.createCaller({}).updateTodo({
+                id: args.id,
+                completed: args.completed,
+            });
+            return {
+                content: [{ type: 'text', text: JSON.stringify(todo, null, 2) }],
+            };
+        }
+        case 'delete_todo': {
+            const id = request.params.arguments?.id;
+            if (typeof id !== 'number') {
+                throw new McpError(ErrorCode.InvalidParams, 'ID must be a number');
+            }
+            await todoRouter.createCaller({}).deleteTodo(id);
+            return {
+                content: [{ type: 'text', text: JSON.stringify({ success: true }, null, 2) }],
+            };
+        }
+        default:
+            throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${request.params.name}`);
+    }
+});
+async function main() {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.log('TodoApp MCP server running on stdio');
+}
+main().catch(console.error);

--- a/packages/mcp-server-todoapp/package.json
+++ b/packages/mcp-server-todoapp/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "mcp-server-todoapp",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc && chmod +x build/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "*",
+    "@trpc/client": "*",
+    "@trpc/server": "*",
+    "trpc": "*",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "typescript": "*"
+  }
+}

--- a/packages/mcp-server-todoapp/src/index.ts
+++ b/packages/mcp-server-todoapp/src/index.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError
+} from '@modelcontextprotocol/sdk/types.js';
+import { initTRPC } from '@trpc/server';
+import { z } from 'zod';
+
+// インメモリデータストア
+interface Todo {
+  id: number;
+  text: string;
+  completed: boolean;
+}
+
+const todos: Todo[] = [];
+let nextTodoId = 1;
+
+// trpc の初期化
+interface Context {
+  auth?: {
+    userId?: string;
+  };
+}
+
+const t = initTRPC.context<Context>().create();
+const router = t.router;
+const publicProcedure = t.procedure;
+
+// 入力スキーマの定義
+const createTodoSchema = z.string();
+const updateTodoSchema = z.object({
+  id: z.number(),
+  completed: z.boolean(),
+});
+const deleteTodoSchema = z.number();
+
+// trpc ルーター定義
+const todoRouter = router({
+  createTodo: publicProcedure
+    .input(createTodoSchema)
+    .mutation(({ input }) => {
+      const todo: Todo = {
+        id: nextTodoId++,
+        text: input,
+        completed: false,
+      };
+      todos.push(todo);
+      return todo;
+    }),
+  listTodos: publicProcedure.query(() => {
+    return todos;
+  }),
+  updateTodo: publicProcedure
+    .input(updateTodoSchema)
+    .mutation(({ input }) => {
+      const todo = todos.find((t) => t.id === input.id);
+      if (!todo) {
+        throw new Error(`Todo with id ${input.id} not found`);
+      }
+      todo.completed = input.completed;
+      return todo;
+    }),
+  deleteTodo: publicProcedure
+    .input(deleteTodoSchema)
+    .mutation(({ input }) => {
+      const index = todos.findIndex((t) => t.id === input);
+      if (index === -1) {
+        throw new Error(`Todo with id ${input} not found`);
+      }
+      todos.splice(index, 1);
+      return { success: true };
+    }),
+});
+
+// MCP サーバーの初期化
+const server = new Server(
+  {
+    name: 'TodoApp MCP Server',
+    version: '0.1.0',
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+// ListToolsRequestSchema のハンドラー
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: 'create_todo',
+        description: 'Create a new todo item',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            text: { type: 'string', description: 'Todo item text' },
+          },
+          required: ['text'],
+        },
+      },
+      {
+        name: 'list_todos',
+        description: 'List all todo items',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      {
+        name: 'update_todo',
+        description: 'Update a todo item (e.g., mark as complete)',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            id: { type: 'number', description: 'Todo item ID' },
+            completed: { type: 'boolean', description: 'Completion status' },
+          },
+          required: ['id', 'completed'],
+        },
+      },
+      {
+        name: 'delete_todo',
+        description: 'Delete a todo item',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            id: { type: 'number', description: 'Todo item ID' },
+          },
+          required: ['id'],
+        },
+      },
+    ],
+  };
+});
+
+// CallToolRequestSchema のハンドラー
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  switch (request.params.name) {
+    case 'create_todo': {
+      const text = request.params.arguments?.text;
+      if (typeof text !== 'string') {
+        throw new McpError(ErrorCode.InvalidParams, 'Text must be a string');
+      }
+      const todo = await todoRouter.createCaller({}).createTodo(text);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(todo, null, 2) }],
+      };
+    }
+    case 'list_todos': {
+      const todos = await todoRouter.createCaller({}).listTodos();
+      return {
+        content: [{ type: 'text', text: JSON.stringify(todos, null, 2) }],
+      };
+    }
+    case 'update_todo': {
+      const args = request.params.arguments;
+      if (
+        typeof args?.id !== 'number' ||
+        typeof args?.completed !== 'boolean'
+      ) {
+        throw new McpError(ErrorCode.InvalidParams, 'Invalid arguments for update_todo');
+      }
+      const todo = await todoRouter.createCaller({}).updateTodo({
+        id: args.id,
+        completed: args.completed,
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(todo, null, 2) }],
+      };
+    }
+    case 'delete_todo': {
+      const id = request.params.arguments?.id;
+      if (typeof id !== 'number') {
+        throw new McpError(ErrorCode.InvalidParams, 'ID must be a number');
+      }
+      await todoRouter.createCaller({}).deleteTodo(id);
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ success: true }, null, 2) }],
+      };
+    }
+    default:
+      throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${request.params.name}`);
+  }
+});
+
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.log('TodoApp MCP server running on stdio');
+}
+
+main().catch(console.error);

--- a/packages/mcp-server-todoapp/tsconfig.json
+++ b/packages/mcp-server-todoapp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "build"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,28 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
 
+  packages/mcp-server-todoapp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: '*'
+        version: 1.1.1
+      '@trpc/client':
+        specifier: '*'
+        version: 10.45.2(@trpc/server@10.45.2)
+      '@trpc/server':
+        specifier: '*'
+        version: 10.45.2
+      trpc:
+        specifier: '*'
+        version: 0.11.3
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
+    devDependencies:
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
 packages:
 
   '@anthropic-ai/sdk@0.33.1':
@@ -96,6 +118,14 @@ packages:
     resolution: {integrity: sha512-siCApQgBn3U8R93TdumLtezRyRIlrA/a63GrTRO1jP31fRyOohpu0iPLvXzsyptxmy7B8GDxr8+r+Phu6mHgzg==}
     engines: {node: '>=18'}
 
+  '@trpc/client@10.45.2':
+    resolution: {integrity: sha512-ykALM5kYWTLn1zYuUOZ2cPWlVfrXhc18HzBDyRhoPYN0jey4iQHEFSEowfnhg1RvYnrAVjNBgHNeSAXjrDbGwg==}
+    peerDependencies:
+      '@trpc/server': 10.45.2
+
+  '@trpc/server@10.45.2':
+    resolution: {integrity: sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==}
+
   '@types/node-fetch@2.6.12':
     resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
 
@@ -119,6 +149,10 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@0.19.2:
+    resolution: {integrity: sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==}
+    deprecated: Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -157,6 +191,14 @@ packages:
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@3.1.0:
+    resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -228,6 +270,10 @@ packages:
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
+
+  follow-redirects@1.5.10:
+    resolution: {integrity: sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==}
+    engines: {node: '>=4.0'}
 
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
@@ -423,6 +469,10 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  trpc@0.11.3:
+    resolution: {integrity: sha512-vfj6WrxYk8XDZzCsFNLwo5WhlKi4IYmVRzRgRQAlcK8zH4sY0yIAlJ7Nd1lZcGFe985GfP2LZLoEsCrMsIl/tA==}
+    deprecated: superseded by @trpc/*-packages - see tRPC.io
+
   turbo-darwin-64@2.3.3:
     resolution: {integrity: sha512-bxX82xe6du/3rPmm4aCC5RdEilIN99VUld4HkFQuw+mvFg6darNBuQxyWSHZTtc25XgYjQrjsV05888w1grpaA==}
     cpu: [x64]
@@ -549,6 +599,12 @@ snapshots:
       raw-body: 3.0.0
       zod: 3.24.1
 
+  '@trpc/client@10.45.2(@trpc/server@10.45.2)':
+    dependencies:
+      '@trpc/server': 10.45.2
+
+  '@trpc/server@10.45.2': {}
+
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 18.19.71
@@ -574,6 +630,12 @@ snapshots:
   array-flatten@1.1.1: {}
 
   asynckit@0.4.0: {}
+
+  axios@0.19.2:
+    dependencies:
+      follow-redirects: 1.5.10
+    transitivePeerDependencies:
+      - supports-color
 
   body-parser@1.20.3:
     dependencies:
@@ -619,6 +681,10 @@ snapshots:
   cookie@0.7.1: {}
 
   debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  debug@3.1.0:
     dependencies:
       ms: 2.0.0
 
@@ -705,6 +771,12 @@ snapshots:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  follow-redirects@1.5.10:
+    dependencies:
+      debug: 3.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -906,6 +978,12 @@ snapshots:
   toidentifier@1.0.1: {}
 
   tr46@0.0.3: {}
+
+  trpc@0.11.3:
+    dependencies:
+      axios: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
 
   turbo-darwin-64@2.3.3:
     optional: true


### PR DESCRIPTION
- Created a new package `mcp-server-todoapp` with a basic structure including `package.json`, `tsconfig.json`, and source files.
- Implemented a simple in-memory Todo application using tRPC for handling CRUD operations.
- Updated `pnpm-lock.yaml` to include new dependencies for the Todo application.
- Added necessary scripts and configurations for building and running the application.